### PR TITLE
Addons to Spring 4 migration of @buehner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
 	<url>http://shogun-webmapping.org</url>
 
 	<properties>
+
 		<java.version>1.6</java.version>
 		<eclipse-plugin.version>2.9</eclipse-plugin.version>
 		<javax.jstl.version>1.2</javax.jstl.version>
@@ -16,9 +17,13 @@
 		<project.build.finalName>SHOGun</project.build.finalName>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <!-- Spring -->
+		<!-- Spring -->
 		<spring.version>4.2.3.RELEASE</spring.version>
 		<spring-security.version>4.0.3.RELEASE</spring-security.version>
+
+		<!-- Hibernate -->
+		<hibernate.version>3.6.10.Final</hibernate.version>
+
 	</properties>
 
 	<repositories>
@@ -55,7 +60,7 @@
 			<version>${jackson.version}</version>
 		</dependency>
 
-		<!-- Spring 3 dependencies -->
+		<!-- Spring dependencies -->
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
@@ -109,12 +114,7 @@
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
-			<version>3.5.6-Final</version>
-		</dependency>
-		<dependency>
-			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-annotations</artifactId>
-			<version>3.5.6-Final</version>
+			<version>${hibernate.version}</version>
 		</dependency>
 
 		<!-- Hibernate Spatial -->

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 
-		<java.version>1.6</java.version>
+		<java.version>1.7</java.version>
 		<eclipse-plugin.version>2.9</eclipse-plugin.version>
 		<javax.jstl.version>1.2</javax.jstl.version>
 		<jackson.version>2.4.2</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -12,11 +12,13 @@
 		<java.version>1.6</java.version>
 		<eclipse-plugin.version>2.9</eclipse-plugin.version>
 		<javax.jstl.version>1.2</javax.jstl.version>
-		<spring.version>4.1.6.RELEASE</spring.version>
-		<spring-security.version>4.0.1.RELEASE</spring-security.version>
 		<jackson.version>2.4.2</jackson.version>
 		<project.build.finalName>SHOGun</project.build.finalName>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- Spring -->
+		<spring.version>4.2.3.RELEASE</spring.version>
+		<spring-security.version>4.0.3.RELEASE</spring-security.version>
 	</properties>
 
 	<repositories>

--- a/src/main/webapp/WEB-INF/spring/app-config.xml
+++ b/src/main/webapp/WEB-INF/spring/app-config.xml
@@ -5,10 +5,10 @@
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:sec="http://www.springframework.org/schema/security"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
-		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
-		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.0.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
+		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
 
 	<!-- This is the root application context configuration, which is declared in the web.xml.
 		 The context of any servlet declared in the web.xml will inherit from this context.

--- a/src/main/webapp/WEB-INF/spring/applicationContext-security.xml
+++ b/src/main/webapp/WEB-INF/spring/applicationContext-security.xml
@@ -12,22 +12,22 @@
 
 	    <!-- see: http://docs.spring.io/spring-security/site/migrate/current/3-to-4/html5/migrate-3-to-4-xml.html#m3to4-xmlnamespace-headers -->
 	    <!-- Disable CSRF as it is enabled by default since Spring Security 4 -->
-	    <csrf disabled="true"/>
+<!-- 	    <csrf disabled="true"/> -->
 	    <!-- TODO make GDABodenschutz work with Security HTTP Response Headers -->
-	    <headers disabled="true"/>
+<!-- 	    <headers disabled="true"/> -->
 
 		<!-- interceptors for special URLs -->
-		<intercept-url pattern="/index*" access="IS_AUTHENTICATED_ANONYMOUSLY"/>
-		<intercept-url pattern="/config/getAppContext.action" access="ROLE_ANONYMOUS, ROLE_USER, ROLE_ADMIN"/>
+		<intercept-url pattern="/index*" access="permitAll"/>
+		<intercept-url pattern="/config/getAppContext.action" access="hasAnyRole('ROLE_ANONYMOUS', 'ROLE_USER','ROLE_ADMIN')"/>
 
 		<!-- default interception -->
-		<intercept-url pattern="/*" access="ROLE_USER, ROLE_ADMIN" />
+		<intercept-url pattern="/*" access="hasAnyRole('ROLE_USER', 'ROLE_ADMIN')" />
 
 		<custom-filter position="FORM_LOGIN_FILTER" ref="authenticationFilter" />
 
 		<!-- Logout configuration -->
 		<logout invalidate-session="true" logout-success-url="/index.html"
-			logout-url="/j_spring_security_logout" />
+			logout-url="/logout" />
 
 		<remember-me key="xaab.springmvclogin" />
 
@@ -48,7 +48,7 @@
 	<!-- the entry point for authentication, via URL -->
 	<beans:bean id="authenticationEntryPoint"
 		class="org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint">
-		<beans:property name="loginFormUrl" value="/index.html" />
+		<beans:constructor-arg name="loginFormUrl" value="/index.html" />
 	</beans:bean>
 
 	<!-- This is an entry point for a custom Authentication Manager,

--- a/src/main/webapp/WEB-INF/spring/applicationContext-security.xml
+++ b/src/main/webapp/WEB-INF/spring/applicationContext-security.xml
@@ -3,12 +3,18 @@
 <beans:beans xmlns="http://www.springframework.org/schema/security"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+						http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
 
 
 	<!-- HTTP configuration for login/logout -->
 	<http auto-config='false' entry-point-ref="authenticationEntryPoint">
+
+	    <!-- see: http://docs.spring.io/spring-security/site/migrate/current/3-to-4/html5/migrate-3-to-4-xml.html#m3to4-xmlnamespace-headers -->
+	    <!-- Disable CSRF as it is enabled by default since Spring Security 4 -->
+	    <csrf disabled="true"/>
+	    <!-- TODO make GDABodenschutz work with Security HTTP Response Headers -->
+	    <headers disabled="true"/>
 
 		<!-- interceptors for special URLs -->
 		<intercept-url pattern="/index*" access="IS_AUTHENTICATED_ANONYMOUSLY"/>

--- a/src/main/webapp/WEB-INF/spring/applicationContext-security.xml
+++ b/src/main/webapp/WEB-INF/spring/applicationContext-security.xml
@@ -11,10 +11,9 @@
 	<http auto-config='false' entry-point-ref="authenticationEntryPoint">
 
 	    <!-- see: http://docs.spring.io/spring-security/site/migrate/current/3-to-4/html5/migrate-3-to-4-xml.html#m3to4-xmlnamespace-headers -->
-	    <!-- Disable CSRF as it is enabled by default since Spring Security 4 -->
-<!-- 	    <csrf disabled="true"/> -->
-	    <!-- TODO make GDABodenschutz work with Security HTTP Response Headers -->
-<!-- 	    <headers disabled="true"/> -->
+	    <!-- Disable CSRF and Security HTTP Response Headers since they are both enabled by default in Spring Security 4 -->
+	    <csrf disabled="true"/>
+	    <headers disabled="true"/>
 
 		<!-- interceptors for special URLs -->
 		<intercept-url pattern="/index*" access="permitAll"/>

--- a/src/main/webapp/WEB-INF/spring/db-config.xml
+++ b/src/main/webapp/WEB-INF/spring/db-config.xml
@@ -6,11 +6,11 @@
     xmlns:util="http://www.springframework.org/schema/util"
     xmlns:context="http://www.springframework.org/schema/context"
     xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
-        http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
-        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+        http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+        http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <!-- Using c3p0 connection pooling.
          See http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/jdbc.html#jdbc-datasource
@@ -77,12 +77,9 @@
 	<!-- Hibernate SessionFactory -->
 	<bean id="sessionFactory"
 		class="org.springframework.orm.hibernate3.annotation.AnnotationSessionFactoryBean">
-		<property name="dataSource">
-			<ref local="dataSource" />
-		</property>
-		<property name="packagesToScan">
-			<ref local="dbEntitiesPackages"></ref>
-		</property>
+		<property name="dataSource" ref="dataSource" />
+        <property name="packagesToScan" ref="dbEntitiesPackages" />
+
 		<property name="hibernateProperties">
 			<props>
 				<!-- <prop key="hibernate.dialect">org.hibernate.dialect.PostgreSQLDialect</prop> -->
@@ -101,9 +98,7 @@
 
 	<bean id="transactionManager"
 		class="org.springframework.orm.hibernate3.HibernateTransactionManager">
-		<property name="sessionFactory">
-			<ref local="sessionFactory" />
-		</property>
+		<property name="sessionFactory" ref="sessionFactory" />
 	</bean>
 
 </beans>

--- a/src/main/webapp/WEB-INF/spring/initialize-beans.xml
+++ b/src/main/webapp/WEB-INF/spring/initialize-beans.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tx="http://www.springframework.org/schema/tx"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
-		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd">
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx.xsd
+		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd">
 
 	<!-- flag for enabling/disabling the automatic init-script on startup -->
 	<bean id="databaseInitializationEnabled" class="java.lang.Boolean">
@@ -138,23 +138,13 @@
 			</list>
 		</property>
 
-		<property name="mapConfigs">
-			<list>
-				<ref local="stdMapConfig" />
-			</list>
-		</property>
+		<property name="mapConfigs" ref="stdMapConfig" />
 
-		<property name="wmsMapLayer">
-			<ref local="stdWmsMapLayer"/>
-		</property>
+		<property name="wmsMapLayer" ref="stdWmsMapLayer"/>
 
-		<property name="defaultAnonymousGroup">
-            <ref local="stdAnonymousGroup"/>
-        </property>
+		<property name="defaultAnonymousGroup" ref="stdAnonymousGroup" />
 
-        <property name="defaultSuperAdminGroup">
-            <ref local="stdSuperAdminGroup"/>
-        </property>
+        <property name="defaultSuperAdminGroup" ref="stdSuperAdminGroup"/>
 
 	</bean>
 

--- a/src/main/webapp/WEB-INF/spring/shogun-config.xml
+++ b/src/main/webapp/WEB-INF/spring/shogun-config.xml
@@ -5,10 +5,10 @@
     xmlns:context="http://www.springframework.org/schema/context"
     xmlns:sec="http://www.springframework.org/schema/security"
     xsi:schemaLocation="
-        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
-        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
-        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.0.xsd">
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
+        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security.xsd">
 
     <!-- This is the context configuration for the shogun-DispatcherServlet
          defined in the web.xml. This context will inherit from the global contextConfigLocation,

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -67,7 +67,7 @@
                 text: 'Logout',
                 disabled: true,
                 handler: function(){
-                    window.location.href = "./j_spring_security_logout";
+                    window.location.href = "./logout";
                 },
                 id: 'logoutBtn'
             }],
@@ -110,7 +110,7 @@
          */
         var login = new Ext.FormPanel({
             labelWidth: 80,
-            url: 'j_spring_security_check',
+            url: 'login',
             frame: true,
             title: 'Login',
             defaultType: 'textfield',
@@ -119,11 +119,11 @@
             monitorValid: true,
             items: [{
                 fieldLabel: 'Username',
-                name: 'j_username',
+                name: 'username',
                 allowBlank: false
             }, {
                 fieldLabel: 'Password',
-                name: 'j_password',
+                name: 'password',
                 inputType: 'password',
                 allowBlank: false
             }],


### PR DESCRIPTION
In this PR, which is based on `spring-4` branch of @buehner, the Spring XML configurations are migrated from 3 to 4. According to the migration guide, especially the schema locations and the access role definitions needed to be updated as well.

Furthermore, Hibernate (`3.5.6-Final` - `3.6.10.Final`), Spring (`4.1.6.RELEASE` - `4.2.3.RELEASE`) and Spring Security (`4.0.1.RELEASE` -> `4.0.3.RELEASE`) have been updated to current (major) stable.

This PR also fixes the broken startup procedure of SHOGun (fails caused by erroneous XML configs).
